### PR TITLE
Removed redundant null checks

### DIFF
--- a/Source/caravanVisual/Patch_WorldDynamicDrawManager_DrawDynamicWorldObjects.cs
+++ b/Source/caravanVisual/Patch_WorldDynamicDrawManager_DrawDynamicWorldObjects.cs
@@ -21,18 +21,10 @@ public class Patch_WorldDynamicDrawManager_DrawDynamicWorldObjects
 
         foreach (var c in dataUtility.dic_caravan.Keys)
         {
-            if (c == null)
+            if (c.def.expandingIcon)
             {
-                dataUtility.Remove(c);
-                continue;
+                c.Draw();
             }
-
-            if (!c.def.expandingIcon)
-            {
-                continue;
-            }
-
-            c.Draw();
         }
     }
 }

--- a/Source/caravanVisual/caravanComponent.cs
+++ b/Source/caravanVisual/caravanComponent.cs
@@ -32,12 +32,6 @@ public class caravanComponent : WorldComponent
 
         foreach (var c in dataUtility.dic_caravan.Keys)
         {
-            if (c == null)
-            {
-                dataUtility.Remove(c);
-                continue;
-            }
-
             cd = dataUtility.GetData(c);
             cd.tryAddPrevPos();
         }


### PR DESCRIPTION
First, dictionaries should not be able contain null keys. Second, trying to call remove with null on a dictionary will cause ArgumentNullException.